### PR TITLE
Add key to trace-forms for passing a var as an optional on/off switch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
 ;          (.trim)
 ;          (subs 1))))
 
-(defproject org.clojars.stumitchell/clairvoyant "0.2.0"
+(defproject org.clojars.stumitchell/clairvoyant "0.2.1-SNAPSHOT"
   :description "ClojureScript tracing library"
   :url "http://github.com/spellhouse/clairvoyant"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
It turned out to be useful during development with react native (re-natal/reagent/re-frame/figwheel) as a quick way to turn tracing on and off when going between running on a device and in the simulator.

p.ex. I have a chrome-mode var in my config namespace which determines whether cljs-devtools are enabled, etc., stuff that only works in a browser and causes errors/warnings/exceptions/issues on a mobile device.

Now I can just do
(trace-forms {:onoffvar cfg/chrome-mode}
    .....)

and clairvoyant is dependent on that flag too, and can be turned on and off in seconds with figwheel hot-reloading.
